### PR TITLE
Fix onDidChangeStatuses of null error

### DIFF
--- a/lib/yuno-commit.coffee
+++ b/lib/yuno-commit.coffee
@@ -8,7 +8,11 @@ intents = ->
     atom.commands.add 'atom-workspace', 'core:save', (event) ->
       observer.onNext(event)
 
-  repositoryStatusUpdates川 = Observable.from(atom.project.getRepositories())
+  repositories = atom.project.getRepositories()
+
+  return refresh川: save川.delay(138) unless repositories[0]
+
+  repositoryStatusUpdates川 = Observable.from(repositories)
     .flatMap (repository) ->
       Observable.create (observer) ->
         repository.onDidChangeStatuses (event) ->


### PR DESCRIPTION
When working in a folder without a git project (for instance when modifying system files), this package throws an error `Cannot call onDidChangeStatuses of null`.

This is because `atom.project.getRepositories()` returned an array with `[null]`.
So running `flatMap` on this will still try to run `onDidChangeStatuses` to listen for these change events on a null repository.

This fixes this issue by returning only the `save` observable if `repositories[0]` is falsey.
